### PR TITLE
Map infobox links to equipment and address is searchable

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,4 +10,5 @@
 
 // Your CSS partials
 @import "components/index";
+@import "components/links";
 @import "pages/index";

--- a/app/assets/stylesheets/components/_links.scss
+++ b/app/assets/stylesheets/components/_links.scss
@@ -1,0 +1,8 @@
+a {
+  color: black;
+  text-decoration: none;
+}
+
+a:hover {
+  color: grey;
+}

--- a/app/controllers/equipment_controller.rb
+++ b/app/controllers/equipment_controller.rb
@@ -15,7 +15,7 @@ class EquipmentController < ApplicationController
 
 
       if params[:query].present?
-        sql_subquery = "sport ILIKE :query OR equipmentname ILIKE :query OR description ILIKE :query"
+        sql_subquery = "sport ILIKE :query OR equipmentname ILIKE :query OR description ILIKE :query OR address ILIKE :query"
         @equipments = @equipments.where(sql_subquery, query: "%#{params[:query]}%")
       end
 

--- a/app/views/equipment/_info_window.html.erb
+++ b/app/views/equipment/_info_window.html.erb
@@ -1,2 +1,2 @@
-<h2><%= equipment.equipmentname %></h2>
+<h2><%= link_to(equipment.equipmentname, equipment_path(equipment)) %></h2>
 <p><%= equipment.address %></p>

--- a/app/views/equipment/_info_window.html.erb
+++ b/app/views/equipment/_info_window.html.erb
@@ -1,2 +1,13 @@
-<h2><%= link_to(equipment.equipmentname, equipment_path(equipment)) %></h2>
-<p><%= equipment.address %></p>
+<%# Photo %>
+<%= link_to equipment_path(equipment) do %>
+  <%= cl_image_tag(equipment.photo.key, class: "img-fluid img-show", alt: "Equipment Image", style: "width: 100%; height: auto; margin-bottom: 10px") %>
+<% end %>
+
+<%# Sports Category %>
+<p style="margin-bottom: 5px"><%= equipment.sport %></p>
+
+<%# Equipment Name %>
+<h5><%= equipment.equipmentname %></h5>
+
+<%# Address %>
+<p style="margin-bottom: 0"><img src="https://cdn-icons-png.flaticon.com/512/2838/2838912.png" alt="Location" width="18px" class="me-1"><%= equipment.address %></p>


### PR DESCRIPTION
We could not manage to put the map to the side of the cards because that would mean we would have to refactor the whole styling/ frontend..

So very little adjustments:
1. I just added a link_to for the infobox on the map. So one can click on the map markers and reach the equipments.
2. Also the address is searchable now through the search bar as well